### PR TITLE
로컬db 사용해서 기존 챗봇 질의 내역 저장. 의존성 주입

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2,20 +2,27 @@ PODS:
   - Flutter (1.0.0)
   - flutter_tts (0.0.1):
     - Flutter
+  - sqflite (0.0.3):
+    - Flutter
+    - FlutterMacOS
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
   - flutter_tts (from `.symlinks/plugins/flutter_tts/ios`)
+  - sqflite (from `.symlinks/plugins/sqflite/darwin`)
 
 EXTERNAL SOURCES:
   Flutter:
     :path: Flutter
   flutter_tts:
     :path: ".symlinks/plugins/flutter_tts/ios"
+  sqflite:
+    :path: ".symlinks/plugins/sqflite/darwin"
 
 SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   flutter_tts: 0f492aab6accf87059b72354fcb4ba934304771d
+  sqflite: 673a0e54cc04b7d6dba8d24fb8095b31c3a99eec
 
 PODFILE CHECKSUM: 819463e6a0290f5a72f145ba7cde16e8b6ef0796
 

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -198,6 +198,7 @@
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
+				04D35D0BEE9104675FD4600D /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -269,6 +270,23 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		04D35D0BEE9104675FD4600D /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;

--- a/lib/config/di_setup.dart
+++ b/lib/config/di_setup.dart
@@ -1,0 +1,31 @@
+import 'package:get_it/get_it.dart';
+import 'package:kobot_client/data/api/chatbot/chatbot_api.dart';
+import 'package:kobot_client/data/api/chatbot/chatbot_api_mock.dart';
+import 'package:kobot_client/data/database/chat_message/chat_message_dao.dart';
+import 'package:kobot_client/data/database/chat_message/chat_message_dao_impl.dart';
+import 'package:kobot_client/data/database/database_helper.dart';
+import 'package:kobot_client/data/repository/chatbot_repo_impl.dart';
+import 'package:kobot_client/domain/repository/chatbot_repo.dart';
+import 'package:kobot_client/presentation/chatbot/chatbot_view_model.dart';
+import 'package:kobot_client/presentation/splash/splash_view_model.dart';
+import 'package:sqflite/sqflite.dart';
+
+GetIt getIt = GetIt.instance;
+
+Future<void> diSetup() async {
+  // 데이터베이스 초기화 및 등록
+  final databaseHelper = DatabaseHelper();
+  final db = await databaseHelper.database;
+  getIt.registerSingleton<Database>(db);
+  getIt.registerSingleton<ChatMessageDao>(ChatMessageDaoImpl(db));
+
+  // API 및 Repository 초기화 및 등록
+  getIt.registerSingleton<ChatbotApi>(ChatbotApiMock());
+  getIt.registerSingleton<ChatbotRepo>(
+    ChatbotRepoImpl(getIt<ChatbotApi>(), getIt<ChatMessageDao>()),
+  );
+
+  // ViewModel 초기화 및 등록
+  getIt.registerFactory(() => ChatbotViewModel(getIt<ChatbotRepo>()));
+  getIt.registerFactory(() => SplashViewModel());
+}

--- a/lib/config/routers.dart
+++ b/lib/config/routers.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
-import 'package:kobot_client/data/api/chatbot/chatbot_api_mock.dart';
-import 'package:kobot_client/data/repository/chatbot_repo_impl.dart';
+import 'package:kobot_client/config/di_setup.dart';
 import 'package:kobot_client/presentation/chatbot/chatbot_screen.dart';
 import 'package:kobot_client/presentation/chatbot/chatbot_view_model.dart';
 import 'package:kobot_client/presentation/splash/splash_screen.dart';
@@ -16,7 +15,7 @@ class Routes {
           path: '/splash',
           builder: (BuildContext context, GoRouterState state) {
             return ChangeNotifierProvider(
-              create: (context) => SplashViewModel(),
+              create: (context) => getIt<SplashViewModel>(),
               child: const SplashScreen(),
             );
           }),
@@ -24,11 +23,7 @@ class Routes {
           path: '/chat',
           builder: (BuildContext context, GoRouterState state) {
             return ChangeNotifierProvider(
-              create: (context) => ChatbotViewModel(
-                ChatbotRepoImpl(
-                  ChatbotApiMock(),
-                ),
-              ),
+              create: (context) => getIt<ChatbotViewModel>(),
               child: const ChatbotScreen(),
             );
           }),

--- a/lib/data/database/chat_message/chat_message_dao.dart
+++ b/lib/data/database/chat_message/chat_message_dao.dart
@@ -1,0 +1,6 @@
+import 'package:kobot_client/domain/model/chat_message.dart';
+
+abstract interface class ChatMessageDao {
+  Future<void> insertMessage(ChatMessage message);
+  Future<List<ChatMessage>> getAllMessages();
+}

--- a/lib/data/database/chat_message/chat_message_dao_impl.dart
+++ b/lib/data/database/chat_message/chat_message_dao_impl.dart
@@ -1,0 +1,39 @@
+import 'package:sqflite/sqflite.dart';
+import 'package:kobot_client/domain/model/chat_message.dart';
+import 'chat_message_dao.dart';
+
+class ChatMessageDaoImpl implements ChatMessageDao {
+  final Database _db;
+
+  ChatMessageDaoImpl(this._db);
+
+  @override
+  Future<void> insertMessage(ChatMessage message) async {
+    await _db.insert(
+      'chat_messages',
+      {
+        'role': message.role.toString().split('.').last,
+        'message': message.message,
+      },
+      conflictAlgorithm: ConflictAlgorithm.replace, // 충돌 시 덮어쓰도록 설정
+    );
+  }
+
+  @override
+  Future<List<ChatMessage>> getAllMessages() async {
+    final List<Map<String, dynamic>> maps = await _db.query('chat_messages');
+
+    return List.generate(maps.length, (i) {
+      return ChatMessage(
+        role: _stringToChatRole(maps[i]['role']),
+        message: maps[i]['message'],
+      );
+    });
+  }
+
+  // String을 ChatRole enum으로 변환
+  ChatRole _stringToChatRole(String role) {
+    return ChatRole.values
+        .firstWhere((e) => e.toString().split('.').last == role);
+  }
+}

--- a/lib/data/database/database_helper.dart
+++ b/lib/data/database/database_helper.dart
@@ -1,0 +1,43 @@
+import 'package:sqflite/sqflite.dart';
+import 'package:path/path.dart';
+
+class DatabaseHelper {
+  static final DatabaseHelper _instance = DatabaseHelper._internal();
+  static Database? _database;
+
+  factory DatabaseHelper() {
+    return _instance;
+  }
+
+  DatabaseHelper._internal();
+
+  Future<Database> get database async {
+    if (_database != null) return _database!;
+    _database = await _initDatabase();
+    return _database!;
+  }
+
+  Future<Database> _initDatabase() async {
+    String path = join(await getDatabasesPath(), 'chatbot.db');
+    return await openDatabase(
+      path,
+      version: 1,
+      onCreate: _onCreate,
+    );
+  }
+
+  Future _onCreate(Database db, int version) async {
+    await db.execute('''
+      CREATE TABLE chat_messages(
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        role TEXT,
+        message TEXT
+      )
+    ''');
+  }
+
+  Future close() async {
+    final db = await database;
+    db.close();
+  }
+}

--- a/lib/data/repository/chatbot_repo_impl.dart
+++ b/lib/data/repository/chatbot_repo_impl.dart
@@ -1,10 +1,13 @@
 import 'package:kobot_client/data/api/chatbot/chatbot_api.dart';
+import 'package:kobot_client/data/database/chat_message/chat_message_dao.dart';
 import 'package:kobot_client/domain/model/chat_message.dart';
 import 'package:kobot_client/domain/repository/chatbot_repo.dart';
 
 class ChatbotRepoImpl implements ChatbotRepo {
   final ChatbotApi _chatbotApi;
-  const ChatbotRepoImpl(this._chatbotApi);
+  final ChatMessageDao _chatMessageDao;
+
+  const ChatbotRepoImpl(this._chatbotApi, this._chatMessageDao);
   @override
   Future<ChatMessage> createChatMessage({required ChatMessage question}) async {
     final String answer =
@@ -13,5 +16,15 @@ class ChatbotRepoImpl implements ChatbotRepo {
         ChatMessage(role: ChatRole.bot, message: answer);
 
     return answerMessage;
+  }
+
+  @override
+  Future<List<ChatMessage>> getAllChatMessages() async {
+    return await _chatMessageDao.getAllMessages();
+  }
+
+  @override
+  Future<void> insertChatMessage(ChatMessage message) async {
+    await _chatMessageDao.insertMessage(message);
   }
 }

--- a/lib/domain/repository/chatbot_repo.dart
+++ b/lib/domain/repository/chatbot_repo.dart
@@ -2,4 +2,6 @@ import 'package:kobot_client/domain/model/chat_message.dart';
 
 abstract interface class ChatbotRepo {
   Future<ChatMessage> createChatMessage({required ChatMessage question});
+  Future<List<ChatMessage>> getAllChatMessages();
+  Future<void> insertChatMessage(ChatMessage message);
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:kobot_client/app.dart';
+import 'package:kobot_client/config/di_setup.dart';
 
-void main() {
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized(); // Flutter 초기화 보장
+  await diSetup(); // 의존성 주입 설정
   runApp(const MyApp());
 }

--- a/lib/presentation/splash/splash_view_model.dart
+++ b/lib/presentation/splash/splash_view_model.dart
@@ -8,13 +8,12 @@ class SplashViewModel extends ChangeNotifier {
   final String _backgroundImg = 'assets/images/kobot_splash_background.png';
   String get backgroundImgPath => _backgroundImg;
 
-  bool? _isLoaded;
-  bool? get isLoaded => _isLoaded;
+  bool _isLoaded = false;
+  bool get isLoaded => _isLoaded;
 
-  void _init() {
-    Future.delayed(const Duration(seconds: 2), () {
-      _isLoaded = true;
-      notifyListeners();
-    });
+  void _init() async {
+    await Future.delayed(const Duration(seconds: 2));
+    _isLoaded = true;
+    notifyListeners();
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -272,6 +272,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
+  get_it:
+    dependency: "direct main"
+    description:
+      name: get_it
+      sha256: d85128a5dae4ea777324730dc65edd9c9f43155c109d5cc0a69cab74139fbac1
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.7.0"
   glob:
     dependency: transitive
     description:
@@ -449,7 +457,7 @@ packages:
     source: hosted
     version: "2.1.0"
   path:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path
       sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
@@ -549,6 +557,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.0"
+  sqflite:
+    dependency: "direct main"
+    description:
+      name: sqflite
+      sha256: a43e5a27235518c03ca238e7b4732cf35eabe863a369ceba6cbefa537a66f16d
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.3+1"
+  sqflite_common:
+    dependency: transitive
+    description:
+      name: sqflite_common
+      sha256: "3da423ce7baf868be70e2c0976c28a1bb2f73644268b7ffa7d2e08eab71f16a4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.4"
   stack_trace:
     dependency: transitive
     description:
@@ -581,6 +605,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
+  synchronized:
+    dependency: transitive
+    description:
+      name: synchronized
+      sha256: "539ef412b170d65ecdafd780f924e5be3f60032a1128df156adad6c5b373d558"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0+1"
   term_glyph:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,6 +44,9 @@ dependencies:
   http: ^1.2.2
   flutter_spinkit: ^5.2.1
   flutter_tts: ^4.0.2
+  sqflite: ^2.3.3+1
+  path: ^1.9.0
+  get_it: ^7.7.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
1. 로컬 db sqflite 사용.
질문을 할때, 답변을 할 때 메세지 저장
앱 실행시 db조회해서 이력이 있는지 확인. 
확장성을 고려하여 interface화 하여 chatMessageDao 구축

2. getIt을 통한 의존성 주입
로컬 db를 사용함으로써 기존에 Router관리하는 곳에서 의존성 주입을 하기가 애매해짐. 
getIt을 통해 db, api, repository, viewmodel 의존성 주입